### PR TITLE
Problem 13 solved.

### DIFF
--- a/src/13-lazy.problem.ts
+++ b/src/13-lazy.problem.ts
@@ -3,12 +3,20 @@
 import { expect, it } from "vitest";
 import { z } from "zod";
 
-const MenuItem = z.object({
-  //             ^ 🕵️‍♂️
-  link: z.string(),
-  label: z.string(),
-  children: z.array(MenuItem).default([]),
-});
+interface MenuItemType {
+  link: string;
+  label: string;
+  children?: MenuItemType[];
+}
+
+const MenuItem: z.ZodType<MenuItemType> = z.lazy(() =>
+  z.object({
+    //             ^ 🕵️‍♂️
+    link: z.string(),
+    label: z.string(),
+    children: z.array(MenuItem).default([]),
+  })
+);
 
 // TESTS
 


### PR DESCRIPTION
以下の Category タイプのような再帰的な schema を持つ型に対して、 遅延評価をするとことで TypeScript のエラーを回避する

```
type Category = {
  name: string
  subcategory: Category[]
}
```