### PR TITLE
Problem 14 solved.

### DIFF
--- a/src/14-generics.problem.ts
+++ b/src/14-generics.problem.ts
@@ -4,7 +4,11 @@ import { it } from "vitest";
 import { z } from "zod";
 import { Equal, Expect } from "./helpers/type-utils";
 
-const genericFetch = (url: string, schema: z.ZodSchema) => {
+// 引数の型をZodSchemaに制約する
+const genericFetch = <ZSchema extends z.ZodSchema>(
+  url: string,
+  schema: ZSchema
+): Promise<z.infer<ZSchema>> => {
   //                 ^ 🕵️‍♂️
   return fetch(url)
     .then((res) => res.json())
@@ -18,11 +22,11 @@ it("Should fetch from the Star Wars API", async () => {
     "https://www.totaltypescript.com/swapi/people/1.json",
     z.object({
       name: z.string(),
-    }),
+    })
   );
 
   type cases = [
     // Result should equal { name: string }, not any
-    Expect<Equal<typeof result, { name: string }>>,
+    Expect<Equal<typeof result, { name: string }>>
   ];
 });


### PR DESCRIPTION
- Generics 型を利用して引数の型を ZodSchema に制約
- z.infer を組み合わせて返り値から zod type を剥がす
https://qiita.com/yu-sugik/items/30757239953a563911e4
https://qiita.com/k-penguin-sato/items/9baa959e8919157afcd4